### PR TITLE
fix: Update yahoo-finance2 to v3 API

### DIFF
--- a/src/lib/fetchDividends.ts
+++ b/src/lib/fetchDividends.ts
@@ -1,4 +1,4 @@
-import yahooFinance from 'yahoo-finance2';
+import YahooFinance from 'yahoo-finance2';
 import type {
   DividendPayment,
   PortfolioStock,
@@ -16,6 +16,8 @@ interface YahooHistoricalDividendRow {
 interface YahooQuote {
   regularMarketPrice?: number;
 }
+
+const yahooFinance = new YahooFinance({ suppressNotices: ['yahooSurvey'] });
 
 /**
  * Fetches dividend history and current stock price for a single ticker from Yahoo Finance


### PR DESCRIPTION
## Summary
- `yahoo-finance2` v3 requires instantiation (`new YahooFinance()`) instead of using the default export directly
- Updated `fetchDividends.ts` to instantiate the client
- Updated test mocks to match the new instantiation pattern

## Test plan
- [x] All 42 unit tests pass
- [ ] Manual test: import sample portfolio via dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)