### PR TITLE
fix: Skip issues with linked PRs in /pr-issue command

### DIFF
--- a/.claude/commands/pr-issue.md
+++ b/.claude/commands/pr-issue.md
@@ -8,7 +8,7 @@ Pick an open GitHub issue, understand it, plan a solution, implement it, and cre
 
 ## Step 1: Pick an Issue
 
-Run `gh issue list --state open` and pick one. Prefer bugs over features, well-defined over vague. Tell the user which issue you picked.
+Run `gh issue list --state open --search "-linked:pr"` to list open issues without existing PRs. Pick one. Prefer bugs over features, well-defined over vague. Tell the user which issue you picked.
 
 ## Step 2: Understand the Issue
 


### PR DESCRIPTION
## Summary
- Filter out issues that already have PRs attached when running `/pr-issue`
- Uses GitHub's `-linked:pr` search syntax to exclude linked issues

## Test plan
- [x] Verified `gh issue list --state open --search "-linked:pr"` excludes issues with linked PRs
- [x] Confirmed issue #10 (which has a linked PR) is filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)