### PR TITLE
feat: Add blocked issue detection to pr-issue command

### DIFF
--- a/.claude/commands/pr-issue.md
+++ b/.claude/commands/pr-issue.md
@@ -10,6 +10,11 @@ Pick an open GitHub issue, understand it, plan a solution, implement it, and cre
 
 Run `gh issue list --state open --search "-linked:pr"` to list open issues without existing PRs. Pick one. Prefer bugs over features, well-defined over vague. Tell the user which issue you picked.
 
+**Skip blocked issues:** Before picking, check if an issue is blocked:
+1. Run `gh api repos/{owner}/{repo}/issues/{number} --jq '.issue_dependencies_summary.blocked_by'` - skip if > 0
+2. Run `gh issue view {number} --json body,comments` and scan for "blocked by" patterns in body/comments
+3. If blocked, add the `blocked` label and move to the next issue
+
 ## Step 2: Understand the Issue
 
 1. Run `gh issue view <number>` for full details


### PR DESCRIPTION
## Summary
- Updates the `/pr-issue` command to check for blocked issues before picking one
- Uses GitHub's built-in issue dependencies API (`issue_dependencies_summary.blocked_by`)
- Also scans body/comments for "blocked by" patterns as a fallback
- Adds `blocked` label to issues that are blocked and moves on

## Context
While testing the `/pr-issue` command, I picked issue #26 which turned out to be blocked by PR #22. This update prevents that situation by checking for blocking dependencies upfront.

Also created a new `blocked` label in the repo and applied it to issue #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)