### PR TITLE
docs: Replace boilerplate README and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Claude Code Instructions
+
+See [README.md](./README.md) for project overview, features, and structure.
+
+## Quick Commands
+
+```bash
+npm run dev      # Start dev server (port 4000)
+npm run build    # Production build
+npm run lint     # ESLint
+npm run format   # Prettier
+npm test         # Unit tests (Vitest)
+npm run e2e      # E2E tests (Playwright)
+```
+
+## Code Patterns
+
+### API Routes
+- Located in `src/app/api/`
+- Use Next.js App Router conventions
+- Return JSON with `{ success: boolean, data?, error? }` pattern
+
+### State Management
+- Jotai atoms in `src/store/`
+- `portfolioAtom` - current working portfolio
+- `persistedPortfolioAtom` - localStorage sync
+
+### Types
+- All TypeScript types defined in `src/lib/types.ts`
+- Key types: `PersistedStock`, `StockWithDividends`, `ProjectionResponse`
+
+### Components
+- UI primitives in `src/components/ui/` (shadcn/ui style)
+- Feature components directly in `src/components/`
+
+## Testing
+
+### Unit Tests
+- Co-located with source: `*.test.ts` next to implementation
+- Run specific file: `npm test -- src/lib/cache.test.ts`
+
+### E2E Tests
+- Located in `tests/e2e/`
+- Tests require dev server running or use `webServer` config in playwright.config.ts
+
+## External Data
+
+- Stock data fetched from Yahoo Finance via `yahoo-finance2`
+- Exchange rates fetched for currency conversion
+- Results cached in `src/lib/cache.ts`

--- a/README.md
+++ b/README.md
@@ -1,36 +1,73 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Dividend Portfolio Projector
+
+A web app for projecting dividend income over 3 years with automatic DRIP (Dividend Reinvestment Plan) calculations.
+
+## Features
+
+- **Portfolio Management**: Add stocks by searching tickers or importing from Avanza CSV exports
+- **Dividend Projection**: View projected dividend payments month-by-month for 3 years
+- **DRIP Simulation**: Automatically reinvests dividends to show compounding growth
+- **Multi-currency Support**: Handles stocks in different currencies (USD, SEK, EUR, etc.)
+- **Stock Suggestions**: Recommends dividend stocks to fill gaps in months with low payouts
+- **Local Storage**: Portfolios persist in browser localStorage
+
+## Tech Stack
+
+- **Framework**: Next.js 16 with App Router
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS 4
+- **State**: Jotai
+- **Data**: yahoo-finance2 for stock/dividend data
+- **Charts**: Recharts
+- **Testing**: Vitest (unit), Playwright (E2E)
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+# Install dependencies
+npm install
+
+# Start development server (port 4000)
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+
+# Open http://localhost:4000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Scripts
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start dev server on port 4000 |
+| `npm run build` | Production build |
+| `npm run lint` | Run ESLint |
+| `npm run format` | Format with Prettier |
+| `npm test` | Run unit tests |
+| `npm run e2e` | Run Playwright E2E tests |
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Project Structure
 
-## Learn More
+```
+src/
+├── app/
+│   ├── api/           # API routes
+│   │   ├── analyze/          # Single stock analysis
+│   │   ├── analyze-portfolio/# Full portfolio projection
+│   │   ├── dividend-info/    # Dividend schedule lookup
+│   │   └── search/           # Stock ticker search
+│   ├── results/       # Results page
+│   └── page.tsx       # Home page
+├── components/        # React components
+├── lib/               # Utilities and business logic
+│   ├── calculateProjection.ts  # DRIP projection engine
+│   ├── fetchDividends.ts       # Yahoo Finance integration
+│   ├── dividendFrequency.ts    # Frequency detection
+│   └── types.ts                # TypeScript types
+└── store/             # Jotai atoms for state
+```
 
-To learn more about Next.js, take a look at the following resources:
+## API Routes
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `POST /api/analyze` - Analyze a single stock
+- `POST /api/analyze-portfolio` - Analyze full portfolio with projections
+- `GET /api/search?q=` - Search for stock tickers
+- `GET /api/dividend-info?ticker=` - Get dividend schedule for a ticker


### PR DESCRIPTION
## Summary

- Replaced the default create-next-app boilerplate README with actual project documentation
- Added CLAUDE.md with agent-specific instructions that references the README

## Changes

**README.md**:
- Project description and features
- Tech stack overview
- Getting started instructions
- Available npm scripts
- Project structure diagram
- API routes documentation

**CLAUDE.md**:
- Links to README for project overview
- Quick command reference
- Code patterns (API routes, state management, types, components)
- Testing instructions
- External data sources

## Test plan

- [x] README renders correctly on GitHub
- [x] CLAUDE.md references README properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)