### PR TITLE
refactor: Avoid default exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ npm run e2e      # E2E tests (Playwright)
 - UI primitives in `src/components/ui/` (shadcn/ui style)
 - Feature components directly in `src/components/`
 
+### Exports
+- Use named exports (not default exports)
+- Exceptions: Next.js pages/layouts and config files require default exports
+- ESLint enforces this via `import/no-default-export`
+
 ## Testing
 
 ### Unit Tests

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,20 @@ const eslintConfig = defineConfig([
       'prefer-const': 'error',
       // No console.log in production code
       'no-console': ['warn', { allow: ['warn', 'error'] }],
+      // Prefer named exports over default exports
+      'import/no-default-export': 'error',
+    },
+  },
+  // Allow default exports for Next.js pages, layouts, and config files
+  {
+    files: [
+      'src/app/**/page.tsx',
+      'src/app/**/layout.tsx',
+      '*.config.ts',
+      '*.config.mjs',
+    ],
+    rules: {
+      'import/no-default-export': 'off',
     },
   },
 ]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import PortfolioView from '@/components/PortfolioView';
+import { PortfolioView } from '@/components/PortfolioView';
 
 export default function Home() {
   return (

--- a/src/app/results/page.tsx
+++ b/src/app/results/page.tsx
@@ -3,7 +3,7 @@
 import { useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { portfolioAtom, portfolioLoadingAtom } from '@/store/portfolioAtom';
-import YearSection from '@/components/YearSection';
+import { YearSection } from '@/components/YearSection';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card } from '@/components/ui/card';

--- a/src/components/DividendBarChart.tsx
+++ b/src/components/DividendBarChart.tsx
@@ -32,7 +32,7 @@ const MONTH_NAMES = [
   'Dec',
 ];
 
-export default function DividendBarChart({
+export function DividendBarChart({
   months,
   selectedMonth,
   onMonthSelect,

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -9,7 +9,7 @@ interface ErrorBannerProps {
   noDividendStocks: StockWithDividends[];
 }
 
-export default function ErrorBanner({
+export function ErrorBanner({
   tickerErrors,
   noDividendStocks,
 }: ErrorBannerProps) {

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -21,7 +21,7 @@ import type { AnalyzeResponse } from '@/lib/types';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
-export default function FileUpload() {
+export function FileUpload() {
   const [isDragging, setIsDragging] = useState(false);
   const [uploadStatus, setUploadStatus] = useAtom(uploadAtom);
   const setPortfolio = useSetAtom(portfolioAtom);

--- a/src/components/MonthDetails.tsx
+++ b/src/components/MonthDetails.tsx
@@ -26,7 +26,7 @@ const MONTH_NAMES = [
   'December',
 ];
 
-export default function MonthDetails({ monthData, onClose }: MonthDetailsProps) {
+export function MonthDetails({ monthData, onClose }: MonthDetailsProps) {
   const monthName = MONTH_NAMES[monthData.month - 1];
   const hasPayments = monthData.payments.length > 0;
 

--- a/src/components/PortfolioView.tsx
+++ b/src/components/PortfolioView.tsx
@@ -5,9 +5,9 @@ import { useAtom, useSetAtom, useAtomValue } from 'jotai';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
-import StockListItem from './StockListItem';
-import StockSearch from './StockSearch';
-import ErrorBanner from './ErrorBanner';
+import { StockListItem } from './StockListItem';
+import { StockSearch } from './StockSearch';
+import { ErrorBanner } from './ErrorBanner';
 import {
   persistedPortfolioAtom,
   addStockAtom,
@@ -24,7 +24,7 @@ import type { AnalyzeResponse, FrequencyInfo, PersistedStock } from '@/lib/types
 import { Plus, Trash2, Upload, TrendingUp, Loader2, Sparkles } from 'lucide-react';
 import { parseCsv } from '@/lib/parseCsv';
 
-export default function PortfolioView() {
+export function PortfolioView() {
   const [portfolio] = useAtom(persistedPortfolioAtom);
   const addStock = useSetAtom(addStockAtom);
   const removeStock = useSetAtom(removeStockAtom);

--- a/src/components/StockListItem.tsx
+++ b/src/components/StockListItem.tsx
@@ -13,7 +13,7 @@ interface StockListItemProps {
   frequencyInfo?: FrequencyInfo;
 }
 
-export default function StockListItem({
+export function StockListItem({
   stock,
   onUpdateShares,
   onDelete,

--- a/src/components/StockSearch.tsx
+++ b/src/components/StockSearch.tsx
@@ -23,7 +23,7 @@ interface StockSearchProps {
   onClose: () => void;
 }
 
-export default function StockSearch({ onAdd, onClose }: StockSearchProps) {
+export function StockSearch({ onAdd, onClose }: StockSearchProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/YearSection.tsx
+++ b/src/components/YearSection.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import DividendBarChart from '@/components/DividendBarChart';
-import MonthDetails from '@/components/MonthDetails';
+import { DividendBarChart } from '@/components/DividendBarChart';
+import { MonthDetails } from '@/components/MonthDetails';
 import type { YearProjection } from '@/lib/types';
 
 interface YearSectionProps {
@@ -10,7 +10,7 @@ interface YearSectionProps {
   data: YearProjection;
 }
 
-export default function YearSection({ year, data }: YearSectionProps) {
+export function YearSection({ year, data }: YearSectionProps) {
   const [selectedMonth, setSelectedMonth] = useState<number | null>(null);
 
   const selectedMonthData = selectedMonth


### PR DESCRIPTION
## Summary
- Converted all component default exports to named exports
- Added ESLint rule `import/no-default-export` to enforce this pattern going forward
- Exceptions configured for Next.js pages/layouts and config files (which require default exports)
- Documented the export pattern in CLAUDE.md

## Test plan
- [x] ESLint passes with no violations
- [x] Build completes successfully
- [x] All 93 unit tests pass

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)