### PR TITLE
fix: Wrap PortfolioView in Suspense boundary for useSearchParams

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { PortfolioView } from '@/components/PortfolioView';
 
 export default function Home() {
@@ -10,7 +11,9 @@ export default function Home() {
           automatic reinvestment
         </p>
       </div>
-      <PortfolioView />
+      <Suspense>
+        <PortfolioView />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wraps PortfolioView component in Suspense boundary on the home page
- Fixes Next.js warning about useSearchParams needing Suspense boundary

## Test plan
- [ ] Verify no console warnings about Suspense boundary
- [ ] Confirm portfolio view renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)